### PR TITLE
Fix usql link

### DIFF
--- a/README.org
+++ b/README.org
@@ -7,7 +7,7 @@ the moment it supports the following interpreters:
 
 - *Python*: requires [[https://pypi.org/project/ipython/][IPython]].
 - *Lua*: requires [[https://luarocks.org/modules/hoelzro/luarepl][luarepl]] and [[https://luarocks.org/modules/dhkolf/dkjson][dkjson]].
-- Various *SQL and NoSQL* databases: based on [[https://github.com/xo/usq][usql]], requires a Go
+- Various *SQL and NoSQL* databases: based on [[https://github.com/xo/usql][usql]], requires a Go
   compiler.
 - *Node.js*: uses the built-in REPL library.
 


### PR DESCRIPTION
A minor fix to point to `usql` link to the right GitHub repository.