### PR TITLE
Fix compatibility with Emacs 31+ 

### DIFF
--- a/drepl.el
+++ b/drepl.el
@@ -76,6 +76,11 @@ buffers, this is a dREPL buffer or nil.")
 (defvar drepl--log-buffer nil
   "Name of the event log buffer, or nil to disable logging.")
 
+(defvar drepl--display-buffer-action
+  (if (boundp 'display-comint-buffer-action) ; Emacs >= 29, <= 30
+      display-comint-buffer-action
+    (append display-buffer--same-window-action '((category . comint)))))
+
 ;;; Basic definitions
 
 (cl-defstruct (drepl-base
@@ -122,7 +127,7 @@ addition to those of `drepl-base'."
               (format "Start the %s interpreter." display-name))
          (interactive)
          (pop-to-buffer (drepl--get-buffer-create ',name t)
-                        display-comint-buffer-action))
+                        drepl--display-buffer-action))
        (cl-defstruct (,name
                       (:include drepl-base (history-variable ',hist-var))
                       (:copier nil)
@@ -324,7 +329,7 @@ interactively."
    (if ask
        (drepl--read-buffer "Pop to REPL: ")
      (drepl--buffer (drepl--get-repl nil t)))
-   display-comint-buffer-action))
+   drepl--display-buffer-action))
 
 ;;; Complete operation
 

--- a/drepl.el
+++ b/drepl.el
@@ -158,15 +158,19 @@ The message is formed by calling `format' with STRING and ARGS."
 ;;; Communication protocol
 
 (defalias 'drepl--json-decode
-  (if (json-available-p)
+  (if (fboundp 'json-parse-string)
       (lambda (s)
         (json-parse-string s :object-type 'alist :null-object nil))
-    (error "Not implemented")))
+    (require 'json)
+    (declare-function json-read-from-string "json" (string))
+    #'json-read-from-string))
 
 (defalias 'drepl--json-encode
-  (if (json-available-p)
+  (if (fboundp 'json-serialize)
       (lambda (s) (json-serialize s :null-object nil))
-    (error "Not implemented")))
+    (require 'json)
+    (declare-function json-encode "json" (object))
+    #'json-encode))
 
 (cl-defgeneric drepl--send-request (repl data)
   "Send request data to REPL.


### PR DESCRIPTION
Emacs 31 removed the deprecated variable `display-comint-buffer-action` [^1].

[^1]: https://github.com/emacs-mirror/emacs/commit/d706be4b345
